### PR TITLE
Fix conflict between system libraries and xDAQ provided libraries

### DIFF
--- a/FindCACTUS.cmake
+++ b/FindCACTUS.cmake
@@ -59,8 +59,9 @@ function(cactus_import_lib name)
     find_library(
         cactus_${name}_library
         cactus_${name}
+        NO_CMAKE_ENVIRONMENT_PATH NO_CMAKE_SYSTEM_PATH
+        HINTS ENV CACTUS_ROOT
         PATHS /opt/cactus/
-        ENV CACTUS_ROOT
         PATH_SUFFIXES lib lib64
         DOC "Root directory of the CACTUS installation")
 
@@ -77,8 +78,9 @@ function(cactus_import_lib name)
     find_file(
         cactus_${name}_header_location
         ${cactus_${name}_header}
+        NO_CMAKE_ENVIRONMENT_PATH NO_CMAKE_SYSTEM_PATH
+        HINTS ENV CACTUS_ROOT
         PATHS /opt/cactus/
-        ENV CACTUS_ROOT
         PATH_SUFFIXES include
         DOC "Root directory of the CACTUS installation")
 

--- a/FindxDAQ.cmake
+++ b/FindxDAQ.cmake
@@ -97,8 +97,9 @@ function(xdaq_import_lib name)
     find_library(
         xdaq_${name}_library
         ${name}
+        NO_CMAKE_ENVIRONMENT_PATH NO_CMAKE_SYSTEM_PATH
+        HINTS ENV XDAQ_ROOT
         PATHS /opt/xdaq/
-        ENV XDAQ_ROOT
         PATH_SUFFIXES lib lib64
         DOC "Root directory of the xDAQ installation")
 
@@ -115,8 +116,9 @@ function(xdaq_import_lib name)
     find_file(
         xdaq_${name}_header_location
         ${xdaq_${name}_header}
+        NO_CMAKE_ENVIRONMENT_PATH NO_CMAKE_SYSTEM_PATH
+        HINTS ENV XDAQ_ROOT
         PATHS /opt/xdaq/
-        ENV XDAQ_ROOT
         PATH_SUFFIXES include
         DOC "Root directory of the xDAQ installation")
 


### PR DESCRIPTION
If a xDAQ provided library is also installed as a system library, this last one takes precedence. We do not want this behavior in xDAQ, so the system paths search must be disabled. The cmake-specific variables, however, are still enabled in order to allow the superbuild.

Also, use the opportunity to move `XDAQ_ROOT` from `PATHS ENV` to `HINTS ENV` so that it takes precedence.