### PR TITLE
Bring FindxDAQ.cmake to release quality

### DIFF
--- a/FindxDAQ.cmake
+++ b/FindxDAQ.cmake
@@ -134,6 +134,11 @@ macro(_xdaq_import_lib name)
             endif()
         endforeach()
 
+        # Threads dependency
+        if(xdaq_${name}_threads AND NOT Threads_FOUND)
+            set(xdaq_${name}_deps_found FALSE)
+        endif()
+
         if(xdaq_${name}_deps_found)
             # May have been overwritten
             string(TOUPPER ${name} uname)

--- a/FindxDAQ.cmake
+++ b/FindxDAQ.cmake
@@ -288,7 +288,7 @@ if(TARGET xDAQ::i2o)
 endif()
 
 # toolbox requires libuuid from the system
-# It is guaranteed that XDAQ_TOOLBOX_FOUND is FALSE when libuuid is not found
+# It is guaranteed that xDAQ_toolbox_FOUND is FALSE when libuuid is not found
 if(xDAQ_toolbox_FOUND)
     set_property(TARGET xDAQ::toolbox
                  APPEND PROPERTY INTERFACE_LINK_LIBRARIES

--- a/FindxDAQ.cmake
+++ b/FindxDAQ.cmake
@@ -148,6 +148,18 @@ macro(_xdaq_import_lib name)
         # Threads dependency
         if(xdaq_${name}_threads AND NOT Threads_FOUND)
             set(xdaq_${name}_deps_found FALSE)
+            set(xDAQ_FOUND FALSE)
+        endif()
+
+        # toolbox requires libuuid from the system
+        if(${name} STREQUAL "toolbox")
+            find_library(xDAQ_UUID_LIBRARY uuid)
+            mark_as_advanced(xDAQ_UUID_LIBRARY)
+
+            if(NOT xDAQ_UUID_LIBRARY)
+                set(xDAQ_FOUND FALSE)
+                set(xdaq_toolbox_deps_found FALSE)
+            endif()
         endif()
 
         if(xdaq_${name}_deps_found)
@@ -278,15 +290,8 @@ if(xDAQ_I2O_FOUND)
 endif()
 
 # toolbox requires libuuid from the system
+# It is guaranteed that xDAQ_TOOLBOX_FOUND is FALSE when libuuid is not found
 if(xDAQ_TOOLBOX_FOUND)
-    find_library(xDAQ_UUID_LIBRARY uuid)
-    mark_as_advanced(xDAQ_UUID_LIBRARY)
-
-    # Maybe we shouldn't fail if not REQUIRED...
-    if(NOT xDAQ_UUID_LIBRARY)
-        message(SEND_ERROR "Could not find libuuid, required by xDAQ library toolbox")
-        set(xDAQ_FOUND FALSE)
-    endif()
     set_property(TARGET xDAQ::toolbox
                  APPEND PROPERTY INTERFACE_LINK_LIBRARIES
                  ${xDAQ_UUID_LIBRARY})

--- a/FindxDAQ.cmake
+++ b/FindxDAQ.cmake
@@ -224,7 +224,7 @@ macro(_xdaq_import_lib name)
             HINTS ENV XDAQ_ROOT
             PATHS /opt/xdaq/
             PATH_SUFFIXES lib lib64
-            DOC "Root directory of the xDAQ installation")
+            DOC "Path of xDAQ library ${name}")
 
         mark_as_advanced(xDAQ_${name}_LIBRARY)
 
@@ -236,7 +236,7 @@ macro(_xdaq_import_lib name)
             HINTS ENV XDAQ_ROOT
             PATHS /opt/xdaq/
             PATH_SUFFIXES include
-            DOC "Root directory of the xDAQ installation")
+            DOC "xDAQ include directory")
 
         mark_as_advanced(xDAQ_INCLUDE_DIRS)
 
@@ -294,7 +294,8 @@ endforeach()
 
 # toolbox requires libuuid from the system
 if(TARGET xDAQ::toolbox)
-    find_library(xDAQ_uuid_LIBRARY uuid)
+    find_library(xDAQ_uuid_LIBRARY uuid
+                 DOC "Path of the uuid library used by xDAQ")
     mark_as_advanced(xDAQ_uuid_LIBRARY)
 
     set_property(TARGET xDAQ::toolbox

--- a/FindxDAQ.cmake
+++ b/FindxDAQ.cmake
@@ -121,10 +121,9 @@ list(REMOVE_DUPLICATES xdaq_requested_libs)
 
 # Turn the recursive list of dependencies into a list of required variables
 foreach(lib ${xDAQ_FIND_COMPONENTS})
-    set(xdaq_${lib}_required_variables xDAQ_${lib}_LIBRARY xDAQ_${lib}_INCLUDE_DIR)
+    set(xdaq_${lib}_required_variables xDAQ_${lib}_LIBRARY xDAQ_INCLUDE_DIRS)
     foreach(dep ${xdaq_${lib}_recursive_depends})
-        list(APPEND xdaq_${lib}_required_variables
-             xDAQ_${dep}_LIBRARY xDAQ_${dep}_INCLUDE_DIR)
+        list(APPEND xdaq_${lib}_required_variables xDAQ_${dep}_LIBRARY)
 
         # Threads
         if(xdaq_${dep}_threads)
@@ -189,7 +188,7 @@ macro(_xdaq_import_lib name)
 
         # Try to find the headers
         find_path(
-            xDAQ_${name}_INCLUDE_DIR
+            xDAQ_INCLUDE_DIRS
             ${xdaq_${name}_header}
             NO_CMAKE_ENVIRONMENT_PATH NO_CMAKE_SYSTEM_PATH
             HINTS ENV XDAQ_ROOT
@@ -197,9 +196,9 @@ macro(_xdaq_import_lib name)
             PATH_SUFFIXES include
             DOC "Root directory of the xDAQ installation")
 
-        mark_as_advanced(xDAQ_${name}_INCLUDE_DIR)
+        mark_as_advanced(xDAQ_INCLUDE_DIRS)
 
-        if(xDAQ_${name}_LIBRARY AND xDAQ_${name}_INCLUDE_DIR)
+        if(xDAQ_${name}_LIBRARY AND xDAQ_INCLUDE_DIRS)
             # Found!
             set(xDAQ_${name}_FOUND TRUE)
 
@@ -222,9 +221,9 @@ macro(_xdaq_import_lib name)
                 xDAQ::${name}
                 PROPERTIES
                 INTERFACE_INCLUDE_DIRECTORIES
-                "${xDAQ_${name}_INCLUDE_DIR};${xDAQ_${name}_INCLUDE_DIR}/linux"
+                "${xDAQ_INCLUDE_DIRS};${xDAQ_INCLUDE_DIRS}/linux"
                 INTERFACE_SYSTEM_INCLUDE_DIRECTORIES
-                "${xDAQ_${name}_INCLUDE_DIR};${xDAQ_${name}_INCLUDE_DIR}/linux")
+                "${xDAQ_INCLUDE_DIRS};${xDAQ_INCLUDE_DIRS}/linux")
 
             # Dependencies aren't written into .so as they should be, so we need to
             # link explicitely
@@ -268,7 +267,6 @@ endif()
 
 # Wrap things up
 set(xDAQ_LIBRARIES "")
-set(xDAQ_INCLUDE_DIRS "")
 
 foreach(lib ${xDAQ_FIND_COMPONENTS})
     find_package_handle_standard_args(
@@ -277,16 +275,14 @@ foreach(lib ${xDAQ_FIND_COMPONENTS})
         REQUIRED_VARS ${xdaq_${lib}_required_variables})
 
     list(APPEND xDAQ_LIBRARIES ${xDAQ_${lib}_LIBRARY})
-    list(APPEND xDAQ_INCLUDE_DIRS ${xDAQ_${lib}_INCLUDE_DIR})
 endforeach()
 
 list(REMOVE_DUPLICATES xDAQ_LIBRARIES)
-list(REMOVE_DUPLICATES xDAQ_INCLUDE_DIRS)
 
 find_package_handle_standard_args(
     xDAQ
     FOUND_VAR xDAQ_FOUND
-    REQUIRED_VARS xDAQ_LIBRARIES xDAQ_INCLUDE_DIRS
+    REQUIRED_VARS xDAQ_INCLUDE_DIRS xDAQ_LIBRARIES
     VERSION_VAR xDAQ_VERSION
     HANDLE_COMPONENTS)
 

--- a/FindxDAQ.cmake
+++ b/FindxDAQ.cmake
@@ -194,22 +194,13 @@ macro(_xdaq_import_lib name)
                     endif()
 
                     # Set include path
-                    set_property(
-                        TARGET xDAQ::${name}
-                        APPEND PROPERTY INTERFACE_INCLUDE_DIRECTORIES
-                        ${xDAQ_${uname}_INCLUDE_DIR})
-                    set_property(
-                        TARGET xDAQ::${name}
-                        APPEND PROPERTY INTERFACE_SYSTEM_INCLUDE_DIRECTORIES
-                        ${xDAQ_${uname}_INCLUDE_DIR})
-                    set_property(
-                        TARGET xDAQ::${name}
-                        APPEND PROPERTY INTERFACE_INCLUDE_DIRECTORIES
-                        ${xDAQ_${uname}_INCLUDE_DIR}/linux)
-                    set_property(
-                        TARGET xDAQ::${name}
-                        APPEND PROPERTY INTERFACE_SYSTEM_INCLUDE_DIRECTORIES
-                        ${xDAQ_${uname}_INCLUDE_DIR}/linux)
+                    set_target_properties(
+                        xDAQ::${name}
+                        PROPERTIES
+                        INTERFACE_INCLUDE_DIRECTORIES
+                        "${xDAQ_${uname}_INCLUDE_DIR};${xDAQ_${uname}_INCLUDE_DIR}/linux"
+                        INTERFACE_SYSTEM_INCLUDE_DIRECTORIES
+                        "${xDAQ_${uname}_INCLUDE_DIR};${xDAQ_${uname}_INCLUDE_DIR}/linux")
 
                     # Dependencies aren't written into .so as they should be, so we need to
                     # link explicitely

--- a/FindxDAQ.cmake
+++ b/FindxDAQ.cmake
@@ -156,13 +156,6 @@ if(xdaq_need_threads)
     find_package(Threads QUIET)
 endif()
 
-# Sets xDAQ_FOUND to FALSE if the given library isn't optional
-function(_xdaq_lib_not_found lib)
-    if(NOT xDAQ_FIND_REQUIRED_${lib})
-        set(xDAQ_FOUND FALSE)
-    endif()
-endfunction()
-
 # Creates an imported target for the given lib
 macro(_xdaq_import_lib name)
 

--- a/FindxDAQ.cmake
+++ b/FindxDAQ.cmake
@@ -87,11 +87,6 @@ if(NOT DEFINED xDAQ_FIND_COMPONENTS)
     set(xDAQ_FIND_COMPONENTS "${xdaq_all_libs}")
 endif()
 
-# Version numbers are not supported
-if(xDAQ_FIND_VERSION)
-    message(WARNING "xDAQ version ${xDAQ_FIND_VERSION} was requested, but version checking is not supported")
-endif()
-
 # Check that all requested libs are known
 foreach(lib ${xDAQ_FIND_COMPONENTS})
     list(FIND xdaq_all_libs ${lib} found)
@@ -263,6 +258,28 @@ if(TARGET xDAQ::toolbox)
     set_property(TARGET xDAQ::toolbox
                  APPEND PROPERTY INTERFACE_LINK_LIBRARIES
                  ${xDAQ_uuid_LIBRARY})
+endif()
+
+# Extract version information
+if(xDAQ_INCLUDE_DIRS AND EXISTS "${xDAQ_INCLUDE_DIR}/xcept/version.h")
+    # xcept seems to be fundamental in xDAQ, so we assume it should always be
+    # present. xDAQ would be quite useless otherwise.
+    file(STRINGS "${xDAQ_INCLUDE_DIR}/xcept/version.h"
+         version_h_contents REGEX "#define XCEPT_VERSION_")
+
+    foreach(line ${version_h_contents})
+        if("${line}" MATCHES "#define XCEPT_VERSION_MAJOR ([0-9])+")
+            set(xDAQ_VERSION_MAJOR ${CMAKE_MATCH_1})
+        elseif("${line}" MATCHES "#define XCEPT_VERSION_MINOR ([0-9])+")
+            set(xDAQ_VERSION_MINOR ${CMAKE_MATCH_1})
+        elseif("${line}" MATCHES "#define XCEPT_VERSION_PATCH ([0-9])+")
+            set(xDAQ_VERSION_PATCH ${CMAKE_MATCH_1})
+        endif()
+    endforeach()
+
+    set(xDAQ_VERSION ${xDAQ_VERSION_MAJOR}.${xDAQ_VERSION_MINOR}.${xDAQ_VERSION_PATCH})
+
+    unset(version_h_contents)
 endif()
 
 # Wrap things up

--- a/FindxDAQ.cmake
+++ b/FindxDAQ.cmake
@@ -75,16 +75,22 @@ endif()
 
 # Check that all requested libs are known
 foreach(lib ${xDAQ_FIND_COMPONENTS})
-    list(FIND "${xdaq_all_libs}" ${lib} found)
-    if(NOT found EQUAL -1)
-        if(xDAQ_FIND_REQUIRED)
-            message(SEND_ERROR "Unknown xDAQ library ${lib} was requested. This is probably due to a programming error.")
-        endif()
+    list(FIND xdaq_all_libs ${lib} found)
+    if(found EQUAL -1)
         set(xDAQ_FOUND FALSE)
-        set(xDAQ_${lib}_FOUND FALSE)
-        message("a false")
         list(REMOVE_ITEM xDAQ_FIND_COMPONENTS ${lib})
+
+        # Notify user
+        set(msg_type STATUS)
+        if(xDAQ_FIND_REQUIRED)
+            set(msg_type SEND_ERROR)
+        endif()
+        if(NOT xDAQ_FIND_QUIETLY)
+            message(${msg_type} "Unknown xDAQ library ${lib} was requested. This is probably due to a programming error.")
+        endif()
+        unset(msg_type)
     endif()
+    unset(found)
 endforeach()
 
 # Check for threading libraries only if required

--- a/FindxDAQ.cmake
+++ b/FindxDAQ.cmake
@@ -34,11 +34,12 @@ _xdaq_library(logudpappender HEADER "log4cplus/log4judpappender.h"
 _xdaq_library(logxmlappender HEADER "log/xmlappender/version.h"
                              DEPENDS config log4cplus)
 _xdaq_library(mimetic HEADER "mimetic/version.h")
+_xdaq_library(occi HEADER "oci.h")
 _xdaq_library(peer HEADER "pt/version.h" DEPENDS config toolbox xcept xoap THREADS)
 _xdaq_library(toolbox HEADER "toolbox/version.h"
                       DEPENDS asyncresolv cgicc log4cplus THREADS)
 _xdaq_library(tstoreclient HEADER "tstore/client/version.h")
-_xdaq_library(tstoreutils HEADER "tstore/utils/version.h")
+_xdaq_library(tstoreutils HEADER "tstore/utils/version.h" DEPENDS occi)
 _xdaq_library(tstore HEADER "tstore/version.h"
                      DEPENDS tstoreclient tstoreutils xalan-c)
 _xdaq_library(xalan-c HEADER "xalanc/Include/XalanVersion.hpp")

--- a/FindxDAQ.cmake
+++ b/FindxDAQ.cmake
@@ -35,7 +35,7 @@ _xdaq_library(logudpappender HEADER "log4cplus/log4judpappender.h"
 _xdaq_library(logxmlappender HEADER "log/xmlappender/version.h"
                              DEPENDS config log4cplus NO_SONAME)
 _xdaq_library(mimetic HEADER "mimetic/version.h")
-_xdaq_library(occi HEADER "oci.h")
+_xdaq_library(occi HEADER "occi.h")
 _xdaq_library(peer HEADER "pt/version.h" DEPENDS config toolbox xcept xoap
                    THREADS NO_SONAME)
 _xdaq_library(toolbox HEADER "toolbox/version.h"

--- a/FindxDAQ.cmake
+++ b/FindxDAQ.cmake
@@ -255,30 +255,26 @@ foreach(lib ${xdaq_required_libs})
 endforeach()
 
 # i2o requires an additional definition
-list(FIND xdaq_required_libs i2o found)
-if(NOT found EQUAL -1)
+if(xDAQ_I2O_FOUND)
     set_property(TARGET xDAQ::i2o
                  APPEND PROPERTY INTERFACE_COMPILE_DEFINITIONS
                  LITTLE_ENDIAN__)
 endif()
-unset(found)
 
 # toolbox requires libuuid from the system
-list(FIND xdaq_required_libs toolbox found)
-if(NOT found EQUAL -1)
-    find_library(xdaq_uuid_library uuid)
-    mark_as_advanced(xdaq_uuid_library)
+if(xDAQ_TOOLBOX_FOUND)
+    find_library(xDAQ_UUID_LIBRARY uuid)
+    mark_as_advanced(xDAQ_UUID_LIBRARY)
 
     # Maybe we shouldn't fail if not REQUIRED...
-    if(NOT xdaq_uuid_library)
+    if(NOT xDAQ_UUID_LIBRARY)
         message(SEND_ERROR "Could not find libuuid, required by xDAQ library toolbox")
         set(xDAQ_FOUND FALSE)
     endif()
     set_property(TARGET xDAQ::toolbox
                  APPEND PROPERTY INTERFACE_LINK_LIBRARIES
-                 ${xdaq_uuid_library})
+                 ${xDAQ_UUID_LIBRARY})
 endif()
-unset(found)
 
 # Cleanup
 foreach(lib ${xdaq_all_libs})

--- a/FindxDAQ.cmake
+++ b/FindxDAQ.cmake
@@ -15,7 +15,7 @@ set(xdaq_all_libs "")
 
 # Declares a library that can be required using the COMPONENTS argument
 macro(_xdaq_library name)
-    cmake_parse_arguments(ARG "THREADS;NO_SONAME" "HEADER" "DEPENDS" "" ${ARGN})
+    cmake_parse_arguments(ARG "THREADS;NO_SONAME" "HEADER" "DEPENDS" ${ARGN})
 
     set(xdaq_${name}_threads ${ARG_THREADS})
     set(xdaq_${name}_header ${ARG_HEADER})

--- a/FindxDAQ.cmake
+++ b/FindxDAQ.cmake
@@ -237,11 +237,6 @@ macro(_xdaq_import_lib name)
                     ${CMAKE_THREAD_LIBS_INIT})
             endif()
         endif()
-
-        # Cleanup
-        unset(xdaq_${name}_deps_found)
-        unset(xdaq_${name}_searching)
-
     endif()
 endmacro()
 

--- a/FindxDAQ.cmake
+++ b/FindxDAQ.cmake
@@ -1,8 +1,62 @@
-#.rst:
-# FindxDAQ
-# --------
-#
-# Finds xDAQ include directory and libraries
+#[========================================================================[.rst:
+
+FindxDAQ
+--------
+
+This module can be used to find libraries provided by the xDAQ framework. It can
+be used using the standard
+`find_package <https://cmake.org/cmake/help/latest/command/find_package.html>`_
+function. It is possible to specify the list of required libraries using the
+`COMPONENTS` and `OPTIONAL_COMPONENTS` arguments of `find_package` (all
+components are required if nothing is specified). The following libraries are
+supported:
+
+* `asyncresolv`
+* `cgicc`
+* `config`
+* `i2o`
+* `log4cplus`
+* `logudpappender`
+* `logxmlappender`
+* `mimetic`
+* `occi`
+* `peer`
+* `toolbox`
+* `tstoreclient`
+* `tstoreutils`
+* `tstore`
+* `xalan-c`
+* `xcept`
+* `xdata`
+* `xdaq`
+* `xdaq2rc`
+* `xerces-c`
+* `xgi`
+* `xoap`
+
+A target of the form `xDAQ::<lib>` is created for every library. Dependencies
+are handled automatically.
+
+The following variables are set by this module:
+
+::
+
+    xDAQ_FOUND          -- If xDAQ was found
+
+    xDAQ_VERSION        -- xDAQ version found e.g. 3.4.0
+    xDAQ_VERSION_MAJOR  -- xDAQ major version found e.g. 3
+    xDAQ_VERSION_MINOR  -- xDAQ minor version found e.g. 4
+    xDAQ_VERSION_PATCH  -- For compatibility only, always 0
+
+    xDAQ_INCLUDE_DIRS   -- xDAQ include directories
+    xDAQ_<lib>_LIBARRY  -- Location of the 'lib' library
+
+..note::
+
+    Version checking depends on the `xcept` library and will not work if it is
+    not present.
+
+#]========================================================================]
 
 include(CMakeParseArguments)
 include(FindPackageHandleStandardArgs)


### PR DESCRIPTION
Let's bring `FindxDAQ.cmake` to a state where it could be used in production. CACTUS will be handled later.

To my knowledge, the following issues still exist:

* [x] `VERSION` isn't supported
* [x] `QUIET` isn't respected
* [x] The include dir is found on a per-target basis, which could theoretically break the build
* [x] Optional components are treated as mandatory
* [x] `FindPackageHandleStandardArgs`
* [x] `IMPORTED_NO_SONAME`
* [x] `libocci`
* [x] The `xDAQ_<LIB>_FOUND` variables don't handle dependencies

Let me know if you find additional issues.