### PR TITLE
FindxDAQ: occi requires ociei

### DIFF
--- a/FindxDAQ.cmake
+++ b/FindxDAQ.cmake
@@ -20,6 +20,7 @@
 # * `logxmlappender`
 # * `mimetic`
 # * `occi`
+# * `ociei` (OCI)
 # * `peer`
 # * `toolbox`
 # * `tstoreclient`
@@ -88,7 +89,8 @@ _xdaq_library(logudpappender HEADER "log4cplus/log4judpappender.h"
 _xdaq_library(logxmlappender HEADER "log/xmlappender/version.h"
                              DEPENDS config log4cplus NO_SONAME)
 _xdaq_library(mimetic HEADER "mimetic/version.h")
-_xdaq_library(occi HEADER "occi.h")
+_xdaq_library(occi HEADER "occi.h" DEPENDS ociei)
+_xdaq_library(ociei HEADER "oci.h")
 _xdaq_library(peer HEADER "pt/version.h" DEPENDS config toolbox xcept xoap
                    THREADS NO_SONAME)
 _xdaq_library(toolbox HEADER "toolbox/version.h"


### PR DESCRIPTION
When used standalone, occi has missing symbols from ociei. Add the latter as a
dependency.