### PR TITLE
New features for FindxDAQ

### DIFF
--- a/FindxDAQ.cmake
+++ b/FindxDAQ.cmake
@@ -313,10 +313,10 @@ if(NOT IS_DIRECTORY "${xDAQ_HTML_DIR}")
 endif()
 
 # Extract version information
-if(xDAQ_INCLUDE_DIRS AND EXISTS "${xDAQ_INCLUDE_DIR}/xcept/version.h")
+if(xDAQ_INCLUDE_DIRS AND EXISTS "${xDAQ_INCLUDE_DIRS}/xcept/version.h")
     # xcept seems to be fundamental in xDAQ, so we assume it should always be
     # present. xDAQ would be quite useless otherwise.
-    file(STRINGS "${xDAQ_INCLUDE_DIR}/xcept/version.h"
+    file(STRINGS "${xDAQ_INCLUDE_DIRS}/xcept/version.h"
          version_h_contents REGEX "#define XCEPT_VERSION_")
 
     foreach(line ${version_h_contents})

--- a/FindxDAQ.cmake
+++ b/FindxDAQ.cmake
@@ -50,6 +50,7 @@
 #     xDAQ_VERSION_PATCH  -- For compatibility only, always 0
 #
 #     xDAQ_INCLUDE_DIRS   -- xDAQ include directories
+#     xDAQ_HTML_DIR       -- Location of xDAQ HTML documents
 #     xDAQ_<lib>_LIBARRY  -- Location of the 'lib' library
 #
 # ..note::
@@ -304,6 +305,13 @@ if(TARGET xDAQ::toolbox)
                  ${xDAQ_uuid_LIBRARY})
 endif()
 
+# Set the HTML directory
+get_filename_component(xDAQ_HTML_DIR "${xDAQ_INCLUDE_DIRS}/../htdocs" ABSOLUTE CACHE)
+mark_as_advanced(xDAQ_HTML_DIR)
+if(NOT IS_DIRECTORY "${xDAQ_HTML_DIR}")
+    set(xDAQ_HTML_DIR xDAQ_HTML_DIR-NOTFOUND)
+endif()
+
 # Extract version information
 if(xDAQ_INCLUDE_DIRS AND EXISTS "${xDAQ_INCLUDE_DIR}/xcept/version.h")
     # xcept seems to be fundamental in xDAQ, so we assume it should always be
@@ -343,7 +351,7 @@ list(REMOVE_DUPLICATES xDAQ_LIBRARIES)
 find_package_handle_standard_args(
     xDAQ
     FOUND_VAR xDAQ_FOUND
-    REQUIRED_VARS xDAQ_INCLUDE_DIRS xDAQ_LIBRARIES
+    REQUIRED_VARS xDAQ_INCLUDE_DIRS xDAQ_LIBRARIES xDAQ_HTML_DIR
     VERSION_VAR xDAQ_VERSION
     HANDLE_COMPONENTS)
 

--- a/FindxDAQ.cmake
+++ b/FindxDAQ.cmake
@@ -13,6 +13,7 @@
 #
 # * `asyncresolv`
 # * `cgicc`
+# * `clntsh` (OCI)
 # * `config`
 # * `i2o`
 # * `log4cplus`
@@ -20,7 +21,6 @@
 # * `logxmlappender`
 # * `mimetic`
 # * `occi`
-# * `ociei` (OCI)
 # * `peer`
 # * `toolbox`
 # * `tstoreclient`
@@ -87,6 +87,7 @@ endmacro()
 # List all supported libs and their dependencies
 _xdaq_library(asyncresolv HEADER "asyncresolv/config.h")
 _xdaq_library(cgicc HEADER "cgicc/Cgicc.h")
+_xdaq_library(clntsh HEADER "oci.h")
 _xdaq_library(config HEADER "config/PackageInfo.h" DEPENDS xcept NO_SONAME)
 _xdaq_library(i2o HEADER "i2o/version.h" DEPENDS config toolbox xcept NO_SONAME)
 _xdaq_library(log4cplus HEADER "log4cplus/config.hxx")
@@ -95,8 +96,7 @@ _xdaq_library(logudpappender HEADER "log4cplus/log4judpappender.h"
 _xdaq_library(logxmlappender HEADER "log/xmlappender/version.h"
                              DEPENDS config log4cplus NO_SONAME)
 _xdaq_library(mimetic HEADER "mimetic/version.h")
-_xdaq_library(occi HEADER "occi.h" DEPENDS ociei)
-_xdaq_library(ociei HEADER "oci.h")
+_xdaq_library(occi HEADER "occi.h" DEPENDS clntsh)
 _xdaq_library(peer HEADER "pt/version.h" DEPENDS config toolbox xcept xoap
                    THREADS NO_SONAME)
 _xdaq_library(toolbox HEADER "toolbox/version.h"

--- a/FindxDAQ.cmake
+++ b/FindxDAQ.cmake
@@ -53,6 +53,11 @@
 #     xDAQ_HTML_DIR       -- Location of xDAQ HTML documents
 #     xDAQ_<lib>_LIBARRY  -- Location of the 'lib' library
 #
+# If `occi` is requested, `FindxDAQ` will look for `occi-abicompat` and add it
+# as an interface library if it is present. Set `xDAQ_SEARCH_OCCI_COMPAT` to
+# `FALSE` to turn off this behavior. When `occi-abicompat` is used, the variable
+# `xDAQ_USES_OCCI_ABICOMPAT` is set to `TRUE`.
+#
 # ..note::
 #
 #     Version checking depends on the `xcept` library and will not work if it is
@@ -303,6 +308,18 @@ if(TARGET xDAQ::toolbox)
     set_property(TARGET xDAQ::toolbox
                  APPEND PROPERTY INTERFACE_LINK_LIBRARIES
                  ${xDAQ_uuid_LIBRARY})
+endif()
+
+# Search for occi-abicompat
+if(xDAQ_SEARCH_OCCI_COMPAT AND TARGET xDAQ::occi)
+    if(NOT DEFINED xDAQ_SEARCH_OCCI_COMPAT)
+        set(xDAQ_SEARCH_OCCI_COMPAT TRUE)
+    endif()
+    find_package(OCCICompat QUIET)
+    if(OCCICompat_FOUND)
+        set(xDAQ_USES_OCCI_ABICOMPAT TRUE)
+        target_link_libraries(xDAQ::occi INTERFACE occi-abicompat)
+    endif()
 endif()
 
 # Set the HTML directory


### PR DESCRIPTION
* Define `xDAQ_HTML_DIR` as the location of the `htdocs` directory
* Add support for `occi-abicompat`

Based on #10.